### PR TITLE
fix: hits.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@
     </samp>
     <br>
     <br>
-    <img src="https://hits.link/hits?url=https%3A%2F%2Fgithub.com%2Fjckli&bgRight=FAA0A0" width="100px"/>
+    <img src="https://hits-app.vercel.app/hits?url=https%3A%2F%2Fgithub.com%2Fjckli&bgRight=FAA0A0" width="100px"/>
   </p>
 </p>


### PR DESCRIPTION
we've recently dropped the hits.link domain because the renewal price was $180, please use the updated/stable one :D!

sorry for the inconvenience!